### PR TITLE
Increased verbosity when a deployment has no triggers in its DC

### DIFF
--- a/src/deployment_config.rs
+++ b/src/deployment_config.rs
@@ -70,8 +70,8 @@ impl Into<Deployment> for DeploymentConfig {
             spec.paused = Some(true);
             eprintln!(
                 "WARNING: deployment {:?} (Namespace {:?}) has been set to paused because there are no triggers in the DeploymentConfig",
-                metadata.name.as_deref().unwrap(),
-                metadata.namespace.as_deref().unwrap()
+                metadata.name.as_deref().unwrap_or_default("Unknown"),
+                metadata.namespace.as_deref().unwrap_or_default("Unknown")
             );
         }
 

--- a/src/deployment_config.rs
+++ b/src/deployment_config.rs
@@ -68,7 +68,11 @@ impl Into<Deployment> for DeploymentConfig {
         } else {
             // if triggers.as_ref().map_or(true, |t| t.is_empty()) {
             spec.paused = Some(true);
-            eprintln!("WARNING: deployment has been set to paused because there are no triggers in the DeploymentConfig")
+            eprintln!(
+                "WARNING: deployment {:?} (Namespace {:?}) has been set to paused because there are no triggers in the DeploymentConfig",
+                metadata.name.as_deref().unwrap(),
+                metadata.namespace.as_deref().unwrap()
+            );
         }
 
         // Delete last-applied annoation as it is no longer correct after the conversion


### PR DESCRIPTION
Instead of just returning `WARNING: deployment has been set to paused...`, the user now gets to see _which_ deployment is affected.  

This is especially useful when piping a `List` to the binary, as you'd have no idea otherwise:  
```sh
❯ oc get DeploymentConfigs -A -o yaml | dc2deploy > ConvertedDeployments.yaml 
WARNING: deployment "<deployment>" (Namespace "<namespace>") has been set to paused because there are no triggers in the DeploymentConfig
```