### PR TITLE
Omit select metadata fields

### DIFF
--- a/src/deployment_config.rs
+++ b/src/deployment_config.rs
@@ -81,6 +81,12 @@ impl Into<Deployment> for DeploymentConfig {
             .as_mut()
             .map(|a| a.remove("kubectl.kubernetes.io/last-applied-configuration"));
 
+        // Nullify other, unneeded metadata
+        metadata.creation_timestamp = None;
+        metadata.generation = None;
+        metadata.resource_version = None;
+        metadata.uid = None; 
+
         // Images are optional in DeploymentConfig buts not in Deployments.
         // Replace emptys image with " ". Used when images are set with image change triggers.
         // iterate over all containers


### PR DESCRIPTION
This change removes the following fields from a generated `Deployment`:
```diff
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: "2025-02-18T21:49:27Z"
-  generation: 2
   name: my-deployment
   namespace: my-namespace
-  resourceVersion: "2784061538"
-  uid: 99f5937c-efcd-48b6-b854-e195742b77f3
```